### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ As this is a python based tool, it should theoretically run on Linux, chromeOS (
 https://www.mozilla.org/en-GB/firefox/new/
 ```
 
-Or for Linux (Tested with Kali) get the non ESR version of Firefox with:
+Or for Debian (but not required for Ubuntu) get the non ESR version of Firefox with:
 ```
 sudo add-apt-repository ppa:mozillateam/firefox-next && sudo apt update && sudo apt upgrade
 ```


### PR DESCRIPTION
On most other Linux distros AFAIK (including Ubuntu, which is derived from Debian) you can easily get the non-ESR version of Firefox without adding any additional repos